### PR TITLE
Added option for bootstrapping with users and ldaputils to dockerfiles

### DIFF
--- a/config/seedData
+++ b/config/seedData
@@ -1,0 +1,10 @@
+{
+	"users":[
+		{"groups":["Alfred_Users"],"name":"user","password":"StrongUserPassword1!"},
+		{"groups":["Alfred_Users","Alfred_PMs"],"name":"manager","password":"StrongUserPassword1!"}
+	],
+	"groups":[
+		"Alfred_Users",
+		"Alfred_PMs"
+	]
+}

--- a/dockerfiles/almalinux
+++ b/dockerfiles/almalinux
@@ -12,7 +12,7 @@ RUN yum update -y && \
   python3-dns python3-gpg python3-devel readline-devel rpcgen systemd-devel \
   tar zlib-devel \
   bind-utils flex dbus-devel libtirpc-devel python3-markdown bison perl-JSON \
-  iproute netcat -y && \
+  iproute netcat jq ldap-utils -y && \
   yum clean all -y
 
 ARG SMB_VERSION=latest
@@ -35,6 +35,7 @@ RUN ./configure && \
 
 WORKDIR /usr/local/sbin
 COPY sbin /usr/local/sbin
+COPY config /usr/local/sambaconfig
 CMD bash -c "samba-domain-provision && samba -F"
 VOLUME /usr/local/samba
 EXPOSE 53 53/udp 88 88/udp 123/udp 135 137/udp 138/udp 139 389 389/udp 445 464 464/udp 636 3268 3269 49152-65535

--- a/dockerfiles/debian
+++ b/dockerfiles/debian
@@ -11,7 +11,7 @@ RUN apt update && apt upgrade -y && \
     python3-all-dev python3-cryptography python3-dbg python3-dev python3-dnspython \
     python3-dnspython python3-gpg python3-markdown \
     python3-dev xsltproc zlib1g-dev liblmdb-dev lmdb-utils \
-    curl libdbus-1-dev vim iproute2 iputils-ping netcat -y && \
+    curl libdbus-1-dev vim iproute2 iputils-ping netcat jq ldap-utils -y && \
     apt clean autoclean && \
     apt autoremove -y
 
@@ -35,6 +35,7 @@ RUN ./configure && \
 
 WORKDIR /usr/local/sbin
 COPY sbin /usr/local/sbin
+COPY config /usr/local/sambaconfig
 CMD bash -c "samba-domain-provision && samba -F"
 VOLUME /usr/local/samba
 EXPOSE 53 53/udp 88 88/udp 123/udp 135 137/udp 138/udp 139 389 389/udp 445 464 464/udp 636 3268 3269 49152-65535

--- a/dockerfiles/rockylinux
+++ b/dockerfiles/rockylinux
@@ -12,7 +12,7 @@ RUN yum update -y && \
   python3-dns python3-gpg python3-devel readline-devel rpcgen systemd-devel \
   tar zlib-devel \
   bind-utils flex dbus-devel libtirpc-devel python3-markdown bison perl-JSON \
-  iproute netcat -y && \
+  iproute netcat jq ldap-utils -y && \
   yum clean all -y
 
 ARG SMB_VERSION=latest
@@ -35,6 +35,7 @@ RUN ./configure && \
 
 WORKDIR /usr/local/sbin
 COPY sbin /usr/local/sbin
+COPY config /usr/local/sambaconfig
 CMD bash -c "samba-domain-provision && samba -F"
 VOLUME /usr/local/samba
 EXPOSE 53 53/udp 88 88/udp 123/udp 135 137/udp 138/udp 139 389 389/udp 445 464 464/udp 636 3268 3269 49152-65535

--- a/dockerfiles/ubuntu
+++ b/dockerfiles/ubuntu
@@ -11,7 +11,7 @@ RUN apt update && apt upgrade -y && \
     python3-all-dev python3-cryptography python3-dbg python3-dev python3-dnspython \
     python3-dnspython python3-gpg python3-markdown \
     python3-dev xsltproc zlib1g-dev liblmdb-dev lmdb-utils \
-    curl libdbus-1-dev vim iproute2 iputils-ping netcat -y && \
+    curl libdbus-1-dev vim iproute2 iputils-ping netcat jq ldap-utils -y && \
     apt clean autoclean && \
     apt autoremove -y
 
@@ -35,6 +35,7 @@ RUN ./configure && \
 
 WORKDIR /usr/local/sbin
 COPY sbin /usr/local/sbin
+COPY config /usr/local/sambaconfig
 CMD bash -c "samba-domain-provision && samba -F"
 VOLUME /usr/local/samba
 EXPOSE 53 53/udp 88 88/udp 123/udp 135 137/udp 138/udp 139 389 389/udp 445 464 464/udp 636 3268 3269 49152-65535

--- a/sbin/samba-domain-provision
+++ b/sbin/samba-domain-provision
@@ -30,6 +30,8 @@ if [[ ! -e "${SAMBA_PATH:-/usr/local/samba}/private/secrets.keytab" ]]; then
       --option="interfaces=lo ${INTERFACE}" \
       --option="bind interfaces only=yes"
 
+
+
   else
 
     samba-tool domain provision \
@@ -42,6 +44,21 @@ if [[ ! -e "${SAMBA_PATH:-/usr/local/samba}/private/secrets.keytab" ]]; then
       --option="dns forwarder=${DNS_FORWARDER}"
 
   fi
+
+
+  IFS=$(echo -en "\n\b")
+
+  for row in $(cat /usr/local/sambaconfig/seedData | jq -r '.groups[]'); do
+    samba-tool group add $row
+  done
+
+  for row in $(cat /usr/local/sambaconfig/seedData | jq -c '.users[]'); do 
+    eval $(echo $row | jq -r '"name="+(.name | @sh),"password="+(.password | @sh)')
+    samba-tool user add $name $password
+    for groupRow in $(echo $row | jq -r '.groups[]'); do
+      samba-tool group addmembers $(echo $groupRow | tr -d '"') $name
+    done
+  done
 
 fi
 

--- a/sbin/update-etc-files
+++ b/sbin/update-etc-files
@@ -27,3 +27,9 @@ if ! grep -q "${SEARCH_DOMAIN}" /etc/krb5.conf; then
   # The krb5.conf location is different from mirror and compiled from source files
   cat "${SAMBA_PATH:-/usr/local/samba}/private/krb5.conf" >/etc/krb5.conf
 fi
+
+# Allow LDAP connections over non-tls connections
+sed -i 's/\[global\]/[global]\n\tldap server require strong auth = no/' /usr/local/samba/etc/smb.conf
+
+# Bind to all interfaces
+sed -i 's/bind interfaces only = Yes/bind interfaces only = no/' /usr/local/samba/etc/smb.conf


### PR DESCRIPTION
Hi! Found your docker setup for samba-ad-dc and have been using it for the dev environment for a project so thanks for releasing this! While using it I found it useful to add a way to seed Active Directory with users during startup so I thought I'd make a PR in case you wanted to integrate it! Additionally, I added the `ldap-utils` package to all the dockerfiles for easy ldap debugging inside the container.

The way the bootstrapping works is it parses a JSON structure of "users" and "groups" like so:

```
{
	"users":[
		{"groups":["Alfred_Users"],"name":"user","password":"StrongUserPassword1!"},
		{"groups":["Alfred_Users","Alfred_PMs"],"name":"manager","password":"StrongUserPassword1!"}
	],
	"groups":[
		"Alfred_Users",
		"Alfred_PMs"
	]
}
```

then bash loops through the records and first creates the groups then the users with the `samba-tool` command.